### PR TITLE
Don't allow tokens that have been pruned

### DIFF
--- a/src/Bridge/AccessTokenRepository.php
+++ b/src/Bridge/AccessTokenRepository.php
@@ -69,7 +69,7 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
      */
     public function isAccessTokenRevoked($tokenId)
     {
-        return $this->database->table('oauth_access_tokens')
-                    ->where('id', $tokenId)->where('revoked', 1)->exists();
+        return !$this->database->table('oauth_access_tokens')
+                    ->where('id', $tokenId)->where('revoked', 0)->exists();
     }
 }


### PR DESCRIPTION
Security bug:
per @parkershepherd:
Because the check in https://github.com/thephpleague/oauth2-server/blob/a798cfdc5d9989b3ee111a063ec49a84046d364a/src/AuthorizationValidators/BearerTokenValidator.php#L64 is essentially a blacklist instead of a whitelist, explicitly revoked tokens become usable again if the revoked entries are pruned. (also if someone was able to generate a valid JWT that didn't match any tokens in the DB, they would be treated as valid)

Intended behavior:
Only tokens explicitly stored in the DB should be valid (a non-revoked entry should exist in the oauth_access_tokens table)

Steps to reproduce

Generate a token
Verify token works on a route
Revoke token in the DB
Verify token results in an authentication error
Delete the token completely from the DB (i.e. Passport::pruneRevokedTokens(); or manually)
The revoked token suddenly becomes usable again